### PR TITLE
Feat/Enhance HTTP method restriction

### DIFF
--- a/srcs/backend/srcs/mysite/oauth/views.py
+++ b/srcs/backend/srcs/mysite/oauth/views.py
@@ -1,6 +1,7 @@
 import requests
 from django.shortcuts import redirect
 from django.http import HttpResponse, JsonResponse, FileResponse
+from django.views.decorators.http import require_http_methods
 from rest_framework_simplejwt.tokens import AccessToken, RefreshToken
 from rest_framework_simplejwt.exceptions import TokenError
 
@@ -20,136 +21,132 @@ logger = logging.getLogger('oauth')
 
 # csrf 토큰을 받기위한 GET 메서드
 @ensure_csrf_cookie
+@require_http_methods(['GET'])
 def crsf(request):
-    if request.method == 'GET':
-        return JsonResponse({'message':"crsf_get"}, status=200)
-    return JsonResponse({'error': 'Method not allowed'}, status=405)
+    return JsonResponse({'message':"crsf_get"}, status=200)
 
 # jwt토큰 반환 API
+@require_http_methods(['POST'])
 def token(request):
-    if request.method == 'POST':
-        error_response = validate_data(request, ['code'])
-        if error_response:
-            return error_response
+    error_response = validate_data(request, ['code'])
+    if error_response:
+        return error_response
 
-        body_data = json.loads(request.body)
-        code = body_data.get('code')
+    body_data = json.loads(request.body)
+    code = body_data.get('code')
 
-        token_url = "https://api.intra.42.fr/oauth/token"
-        data = {
-            "code": code,
-            "client_id": os.getenv("UID_KEY"),
-            "client_secret": os.getenv("SECRET_KEY"),
-            "redirect_uri": os.getenv("REDIRECTION_URI"),
-            "grant_type": "authorization_code",
-        }
+    token_url = "https://api.intra.42.fr/oauth/token"
+    data = {
+        "code": code,
+        "client_id": os.getenv("UID_KEY"),
+        "client_secret": os.getenv("SECRET_KEY"),
+        "redirect_uri": os.getenv("REDIRECTION_URI"),
+        "grant_type": "authorization_code",
+    }
 
-        token_response = requests.post(token_url, data=data).json()
-        if "error" in token_response:
-            return JsonResponse({"error": token_response["error"]}, status=400)
+    token_response = requests.post(token_url, data=data).json()
+    if "error" in token_response:
+        return JsonResponse({"error": token_response["error"]}, status=400)
 
-        api_url = "https://api.intra.42.fr/v2/me"
-        headers = {"Authorization": f"Bearer {token_response["access_token"]}"}
-        api_response = requests.get(api_url, headers=headers).json()
+    api_url = "https://api.intra.42.fr/v2/me"
+    headers = {"Authorization": f"Bearer {token_response["access_token"]}"}
+    api_response = requests.get(api_url, headers=headers).json()
 
-        user, created = TCDUser.objects.update_or_create(
-            id = api_response["id"],
-            defaults = {
-                "login": api_response["login"],
-                "email": api_response["email"],
-                "first_name": api_response["first_name"],
-                "last_name": api_response["last_name"],
-                "image_url": api_response["image"]["link"],
-            },
-        )
+    user, created = TCDUser.objects.update_or_create(
+        id = api_response["id"],
+        defaults = {
+            "login": api_response["login"],
+            "email": api_response["email"],
+            "first_name": api_response["first_name"],
+            "last_name": api_response["last_name"],
+            "image_url": api_response["image"]["link"],
+        },
+    )
 
-        two_factor_secret_key = user.two_factor_secret_key
+    two_factor_secret_key = user.two_factor_secret_key
 
-        refresh_token = RefreshToken.for_user(user)
-        return JsonResponse({
-            'refresh_token': str(refresh_token),
-            'access_token': str(refresh_token.access_token),
-            'two_factor_required': not bool(two_factor_secret_key)
-        })
-    return JsonResponse({'error': 'Method not allowed'}, status=405)
+    refresh_token = RefreshToken.for_user(user)
+    return JsonResponse({
+        'refresh_token': str(refresh_token),
+        'access_token': str(refresh_token.access_token),
+        'two_factor_required': not bool(two_factor_secret_key)
+    })
 
+@require_http_methods(['GET'])
 def qrcode_image(request):
-    if request.method == 'GET':
-        access_token = get_access_token(request)
-        try:
-            # Access Token 검증
-            token = AccessToken(access_token)  # 토큰 서명 및 유효성 검증
-        except TokenError as e:
-            # 검증 실패 (만료되었거나, 위조된 토큰)
-            return JsonResponse({'message': f'Token is invalid: {str(e)}'}, status=401)
-        user_id = token['user_id']  # 페이로드에서 user_id 추출
+    access_token = get_access_token(request)
+    try:
+        # Access Token 검증
+        token = AccessToken(access_token)  # 토큰 서명 및 유효성 검증
+    except TokenError as e:
+        # 검증 실패 (만료되었거나, 위조된 토큰)
+        return JsonResponse({'message': f'Token is invalid: {str(e)}'}, status=401)
+    user_id = token['user_id']  # 페이로드에서 user_id 추출
 
-        # TCDUser 모델에서 user_id에 해당하는 사용자 정보 가져오기
-        user = TCDUser.objects.get(id = user_id)
+    # TCDUser 모델에서 user_id에 해당하는 사용자 정보 가져오기
+    user = TCDUser.objects.get(id = user_id)
 
-        # user에게 등록된 2fa코드가 이미 있다면 에러 반환
-        if bool(user.two_factor_secret_key):
-            return JsonResponse({
-                'error':'이미 등록된 유저입니다.'
-            }, status=401)
-        
-        # qrcode url생성하는데 필요한 변수들
-        issuer = os.getenv('DJANGO_ISSUER')
-        account_name = user.email
-        secret = pyotp.random_base32()
-        
-        # 2fa 비밀키를 데이터베이스에 저장
-        # [fix point] 추후 암호화해서 저장하는 로직이 필요함.
-        user.two_factor_secret_key = secret
-        user.save()
-        
-        qrCodeUrl = f"otpauth://totp/{issuer}:{account_name}?secret={secret}&issuer={issuer}"
-        # qr = qrcode.make(qrCodeUrl)
-        # qr.save(f"images/{user.login}_2fa_qr_code.png")  # 파일로 저장
-        # file_path = f"./images/{user.login}_2fa_qr_code.png"
-
-        # return FileResponse(open(file_path, "rb"), content_type="image/png")
+    # user에게 등록된 2fa코드가 이미 있다면 에러 반환
+    if bool(user.two_factor_secret_key):
         return JsonResponse({
-            'qrCodeUrl':qrCodeUrl
-        })
-    return JsonResponse({'error': 'Method not allowed'}, status=405)
+            'error':'이미 등록된 유저입니다.'
+        }, status=401)
 
+    # qrcode url생성하는데 필요한 변수들
+    issuer = os.getenv('DJANGO_ISSUER')
+    account_name = user.email
+    secret = pyotp.random_base32()
+
+    # 2fa 비밀키를 데이터베이스에 저장
+    # [fix point] 추후 암호화해서 저장하는 로직이 필요함.
+    user.two_factor_secret_key = secret
+    user.save()
+
+    qrCodeUrl = f"otpauth://totp/{issuer}:{account_name}?secret={secret}&issuer={issuer}"
+    # qr = qrcode.make(qrCodeUrl)
+    # qr.save(f"images/{user.login}_2fa_qr_code.png")  # 파일로 저장
+    # file_path = f"./images/{user.login}_2fa_qr_code.png"
+    
+    # return FileResponse(open(file_path, "rb"), content_type="image/png")
+    return JsonResponse({
+        'qrCodeUrl':qrCodeUrl
+    })
+
+@require_http_methods(['GET'])
 def refresh_qrcode_image(request):
-    if request.method == 'GET':
-        access_token = get_access_token(request)
-        try:
-            # Access Token 검증
-            token = AccessToken(access_token)  # 토큰 서명 및 유효성 검증
-        except TokenError as e:
-            # 검증 실패 (만료되었거나, 위조된 토큰)
-            return JsonResponse({'message': f'Token is invalid: {str(e)}'}, status=401)
-        user_id = token['user_id']  # 페이로드에서 user_id 추출
-
-        # TCDUser 모델에서 user_id에 해당하는 사용자 정보 가져오기
-        user = TCDUser.objects.get(id = user_id)
-
-        # 등록되지 않았아면 리프레시 해주지 않음.
-        if not bool(user.two_factor_secret_key):
-            return JsonResponse({
-                'error':'아직 등록되지 않았습니다.'
-            }, status=401)
-        issuer = os.getenv('DJANGO_ISSUER')
-        account_name = user.email
-        secret = pyotp.random_base32()
-        
-        user.two_factor_secret_key = secret
-        user.save()
-        
-        qrCodeUrl = f"otpauth://totp/{issuer}:{account_name}?secret={secret}&issuer={issuer}"
-        # qr = qrcode.make(qrCodeUrl)
-        # qr.save(f"images/{user.login}_2fa_qr_code.png")  # 파일로 저장
-        # file_path = f"./images/{user.login}_2fa_qr_code.png"
-
-        # return FileResponse(open(file_path, "rb"), content_type="image/png")
+    access_token = get_access_token(request)
+    try:
+        # Access Token 검증
+        token = AccessToken(access_token)  # 토큰 서명 및 유효성 검증
+    except TokenError as e:
+        # 검증 실패 (만료되었거나, 위조된 토큰)
+        return JsonResponse({'message': f'Token is invalid: {str(e)}'}, status=401)
+    user_id = token['user_id']  # 페이로드에서 user_id 추출
+    
+    # TCDUser 모델에서 user_id에 해당하는 사용자 정보 가져오기
+    user = TCDUser.objects.get(id = user_id)
+    
+    # 등록되지 않았아면 리프레시 해주지 않음.
+    if not bool(user.two_factor_secret_key):
         return JsonResponse({
-            'qrCodeUrl':qrCodeUrl
-        })
-    return JsonResponse({'error': 'Method not allowed'}, status=405)
+            'error':'아직 등록되지 않았습니다.'
+        }, status=401)
+    issuer = os.getenv('DJANGO_ISSUER')
+    account_name = user.email
+    secret = pyotp.random_base32()
+    
+    user.two_factor_secret_key = secret
+    user.save()
+    
+    qrCodeUrl = f"otpauth://totp/{issuer}:{account_name}?secret={secret}&issuer={issuer}"
+    # qr = qrcode.make(qrCodeUrl)
+    # qr.save(f"images/{user.login}_2fa_qr_code.png")  # 파일로 저장
+    # file_path = f"./images/{user.login}_2fa_qr_code.png"
+    
+    # return FileResponse(open(file_path, "rb"), content_type="image/png")
+    return JsonResponse({
+        'qrCodeUrl':qrCodeUrl
+    })
 
 # 2fa 검증용 코드
 def authorization_2fa(request):


### PR DESCRIPTION
## PR 제목
- Enhance HTTP method restriction

## 작업 내용 (What)
- if문으로 확인하던 HTTP method 예외처리를 `require_http_methods` 데코레이터로 대체.

## 이유 (Why)
- 코드의 간결함. 코드 작성의 편리함.

## 변경 사항 (Changes)
- 각 뷰의 if문 바깥에서 반환하는 `405 Method Not Allowed`를 삭제, 데코레이터 삽입.

## 테스트 (How)
- `curl -i [api...]` 로 확인.
  - POST로 제한된 api를 호출했을 떄 405 반환됨.
  - GET은 정상 동작.

## 참고 사항
- 리뷰어가 참고할 만한 추가 자료가 있다면 여기에 작성하세요.
  - 관련 링크, 문서, 이슈 번호 등.

---

### 체크리스트
- [x] 코드가 의도한 대로 작동합니다.
- [x] 변경 사항이 문서화되었습니다.
- [x] 기존 테스트를 통과했으며, 필요한 경우 새로운 테스트를 추가했습니다.

---

### 이슈 번호
- #4 
