### PR TITLE
feat: change APIView to ModelViewSet

### DIFF
--- a/srcs/backend/srcs/mysite/users/urls.py
+++ b/srcs/backend/srcs/mysite/users/urls.py
@@ -1,7 +1,12 @@
-from django.urls import path
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
 from . import views
 
+router = DefaultRouter()
+router.register(r'auth', views.UserAuthViewSet)
+router.register('', views.UserViewSet, basename='user-list')
+router.register(r'\w+', views.UserViewSet, basename='user-detail')
+
 urlpatterns = [
-    path('', views.UserView.as_view()),
-    path('auth', views.UserAuthView.as_view()),
+    path('', include(router.urls)),
 ]

--- a/srcs/backend/srcs/mysite/users/views.py
+++ b/srcs/backend/srcs/mysite/users/views.py
@@ -1,7 +1,8 @@
 from django.shortcuts import render
-from rest_framework.views import APIView
+from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.decorators import action
 from django.http import JsonResponse
 from rest_framework_simplejwt.tokens import AccessToken
 from django.shortcuts import get_object_or_404
@@ -13,17 +14,26 @@ import logging
 logger = logging.getLogger('users') 
 
 # Create your views here.
-class UserView(APIView):
-    authentication_classes = []
-    permission_classes = []
-    def get(self, request):
-        users = CustomUser.objects.all()  # QuerySet 가져오기
-        serializer = CustomUserSerializer(users, many=True)  # many=True 옵션
+
+class UserAuthViewSet(viewsets.ModelViewSet):
+    queryset = CustomUser.objects.all()
+    serializer_class = CustomUserSerializer
+
+    @action(detail=False, methods=['get'], url_path='')
+    def get_auth_user(self, request):
+        user = request.user
+        serializer = CustomUserSerializer(user)
         return Response(serializer.data)
 
 
-class UserAuthView(APIView):
-    def get(self, request):
-        user = request.user
+class UserViewSet(viewsets.ModelViewSet):
+    authentication_classes = []
+    permission_classes = []
+    queryset = CustomUser.objects.all()
+    serializer_class = CustomUserSerializer
+
+    # override the basic retrieve() to search user by username, not by primary key
+    def retrieve(self, request, pk=None):
+        user = get_object_or_404(CustomUser, username=pk)
         serializer = CustomUserSerializer(user)
         return Response(serializer.data)


### PR DESCRIPTION
## PR 제목
- change APIView to ModelViewSet

## 작업 내용 (What)
- `UserAuthView`와 `UserView`의 베이스 클래스를 `APIView`에서 `ModelViewSet`으로 변경.
- `GET /api/users/[user_name]` 추가.

## 이유 (Why)
- `ModelViewSet`은 `APIView`와 동일한 토큰 검사 등을 제공하면서 여러 기본적인 뷰 함수들을 제공해준다.
  - `ViewSet`은 이와 비슷하지만 `list()`, `retrieve()` 등 기본 액션들을 직접 정의해야 한다. 반면에 `ModelViewSet`은 이미 정의되어 있어 오버라이딩을 하지 않아도 된다.
    - 기존에 `UserView` 클래스에 `get()` 으로 정의되어 있던 부분을 아예 제거했지만 `GET /api/users/` 를 요청하면 똑같이 동작한다.

## 변경 사항 (Changes)
- 다른 변경사항은, `UserView`, `UserAuthView` 클래스를 각각 `UserViewSet`, `UserAuthViewSet`으로 이름을 변경했다.
  - 여러 개의 뷰를 정의하기 때문에 Set을 붙였다.

## 테스트 (How)
- 모두 GET 요청이라 브라우저와 curl로 테스트했다.

## 참고 사항
- https://www.django-rest-framework.org/api-guide/viewsets/#modelviewset

---

### 체크리스트
- [x] 코드가 의도한 대로 작동합니다.
- [x] 변경 사항이 문서화되었습니다.
- [x] 기존 테스트를 통과했으며, 필요한 경우 새로운 테스트를 추가했습니다.

---

### 이슈 번호
