### PR TITLE
fix: TwoFactorView_POST access_token is not str

### DIFF
--- a/srcs/backend/srcs/mysite/oauth/views.py
+++ b/srcs/backend/srcs/mysite/oauth/views.py
@@ -112,7 +112,7 @@ class TokenRefreshView(APIView):
     authentication_classes = []
     permission_classes = []
     def post(self, request):
-        old_refresh_token = request.COOKIE.get('refresh_token')
+        old_refresh_token = request.COOKIES.get('refresh_token')
         try:
             old_refresh_token = RefreshToken(old_refresh_token)
         except TokenError as e:
@@ -191,7 +191,7 @@ class TwoFactorView(APIView):
             access_token['is_2fa_authenticated'] =True
 
             response = Response({
-                'access_token': access_token
+                'access_token': str(access_token)
             })
 
             response.set_cookie(


### PR DESCRIPTION
## PR 제목
2FA 인증 성공 이후 넘기는 AccessToken이 str 형식이 아닌점을 수정

## 작업 내용 (What)
2FA 인증 성공 이후 넘기는 AccessToken이 str 형식이 아닌점을 수정

## 이유 (Why)
프론트엔드에서 JWT토클을 str로 갖고있어야하기 때문에 수정했습니다.

## 변경 사항 (Changes)
oauth/view/TwoFactorView/POST
access_token을 str(access_token) 으로 변경

## 테스트 (How)
웹 브라우저 테스트

## 참고 사항


---

### 체크리스트
- [x] 코드가 의도한 대로 작동합니다.
- [x] 변경 사항이 문서화되었습니다.
- [x] 기존 테스트를 통과했으며, 필요한 경우 새로운 테스트를 추가했습니다.

---

### 이슈 번호
- 관련된 이슈 번호를 작성합니다. (예: Fixes #123, Closes #456)
close #17