### PR TITLE
Fix/let PATCH api/users/me/ work properly

### DIFF
--- a/srcs/backend/srcs/mysite/users/urls.py
+++ b/srcs/backend/srcs/mysite/users/urls.py
@@ -3,10 +3,10 @@ from rest_framework.routers import DefaultRouter
 from . import views
 
 router = DefaultRouter()
-router.register(r'me', views.UserAuthViewSet)
 router.register('', views.UserViewSet, basename='user-list')
 router.register(r'\w+', views.UserViewSet, basename='user-detail')
 
 urlpatterns = [
+    path('me/', views.UserAuthViewSet.as_view()),
     path('', include(router.urls)),
 ]

--- a/srcs/backend/srcs/mysite/users/urls.py
+++ b/srcs/backend/srcs/mysite/users/urls.py
@@ -7,6 +7,6 @@ router.register('', views.UserViewSet, basename='user-list')
 router.register(r'\w+', views.UserViewSet, basename='user-detail')
 
 urlpatterns = [
-    path('me/', views.UserAuthViewSet.as_view()),
+    path('me/', views.UserAuthView.as_view()),
     path('', include(router.urls)),
 ]

--- a/srcs/backend/srcs/mysite/users/views.py
+++ b/srcs/backend/srcs/mysite/users/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
 from rest_framework import viewsets
+from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.decorators import action
 from django.http import JsonResponse
@@ -12,14 +13,20 @@ logger = logging.getLogger('users')
 
 # Create your views here.
 
-class UserAuthViewSet(viewsets.ModelViewSet):
-    queryset = CustomUser.objects.all()
-    serializer_class = CustomUserSerializer
-
-    def list(self, request):
+class UserAuthViewSet(APIView):
+    def get(self, request):
         user = request.user
         serializer = CustomUserSerializer(user)
         return Response(serializer.data)
+
+    def patch(self, request):
+        user = request.user
+        data = request.data
+        serializer = CustomUserSerializer(user, data=data, partial=True)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data)
+        return Response({"error": "Cannot update user"}, status=400)
 
 
 class UserViewSet(viewsets.ModelViewSet):

--- a/srcs/backend/srcs/mysite/users/views.py
+++ b/srcs/backend/srcs/mysite/users/views.py
@@ -13,7 +13,7 @@ logger = logging.getLogger('users')
 
 # Create your views here.
 
-class UserAuthViewSet(APIView):
+class UserAuthView(APIView):
     def get(self, request):
         user = request.user
         serializer = CustomUserSerializer(user)
@@ -23,7 +23,7 @@ class UserAuthViewSet(APIView):
         user = request.user
         data = request.data
         if not data:
-            return Response({'error': 'The request body is empty'})
+            return Response({'error': 'The request body is empty.'}, status=400)
         serializer = CustomUserSerializer(user, data=data, partial=True)
         if serializer.is_valid():
             serializer.save()

--- a/srcs/backend/srcs/mysite/users/views.py
+++ b/srcs/backend/srcs/mysite/users/views.py
@@ -22,11 +22,13 @@ class UserAuthViewSet(APIView):
     def patch(self, request):
         user = request.user
         data = request.data
+        if not data:
+            return Response({'error': 'The request body is empty'})
         serializer = CustomUserSerializer(user, data=data, partial=True)
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data)
-        return Response({"error": "Cannot update user"}, status=400)
+        return Response({'error': 'Cannot update user'}, status=400)
 
 
 class UserViewSet(viewsets.ModelViewSet):
@@ -41,7 +43,7 @@ class UserViewSet(viewsets.ModelViewSet):
         partial_name = request.GET.get('partial_name')
         serializer = CustomUserPatternSerializer(partial_name)
         if not serializer.data.get('user_list'):
-            return Response({"error": "User not found"}, status=400)
+            return Response({'error': 'User not found'}, status=400)
         return Response(serializer.data)
 
     # override the basic retrieve() to search user by username, not by primary key
@@ -50,5 +52,5 @@ class UserViewSet(viewsets.ModelViewSet):
             user = CustomUser.objects.get(username=pk)
             serializer = CustomUserSerializer(user)
         except CustomUser.DoesNotExist:
-            return Response({"error": "User not found"}, status=400)
+            return Response({'error': 'User not found'}, status=400)
         return Response(serializer.data)


### PR DESCRIPTION
## PR 제목
- let PATCH api/users/me/ work properly

## 작업 내용 (What)
- UserAuthViewSet의 베이스 클래스를 다시 APIView로 변경.
- UserAuthViewSet의 이름을 UserAuthView로 변경.
- PATCH api/users/me 를 명시적으로 구현. `def patch()`

## 이유 (Why)
- api/users/me/는 하나의 리소스에 http method만 바뀌기 때문에 APIView가 url 매핑하기 훨씬 편리함.. 굳이 복잡하게 action을 따로 지정할 필요가 없다.
- 무엇보다 기존 코드에서 PATCH api/users/me/ 가 작동하지 않고 있었다. ModelViewSet에서 자동으로 해주는 줄 알고 구현을 안 했는데 알고 보니 ModelViewSet에서 정의한 기본 뷰 함수들 중 PATCH에 해당하는 partial_update나 update의 경우, 필수적으로 pk를 인자로 받고 있었다. (`def update(self, request, pk=None)...`) 여기에 매핑되는 url은 base url인 api/users/me/ + \<pk\> 여서 API와 맞지 않는다
- 결론: PATCH가 안 돌아가서 겸사겸사 편하게 다시 APIView로 변경. 현재는 잘 됨.

## 변경 사항 (Changes)
- [작업 내용]과 동.

## 테스트 (How)
- postman으로 `PATCH api/users/me/` 테스트. username 변경 시도. seojilee1 -> seojilee2. 성공.
- 이미 존재하는 다른 유저와 필드 내용이 겹칠 경우 400 반환.
- http body 내용이 없을 때 400 반환.

## 참고 사항
- (솔직히 api/users/[username]/follows/ 를 가지는 UserViewSet 말고는 대부분 다시 APIView로 바꿔도 될 것 같다. api/[app_name]/... 로 api 구조를 바꿔서 굉장히 편해짐. 코멘트 달아주시면 참고해서 바꿔볼게요.)

---

### 체크리스트
- [x] 코드가 의도한 대로 작동합니다.
- [x] 변경 사항이 문서화되었습니다.
- [x] 기존 테스트를 통과했으며, 필요한 경우 새로운 테스트를 추가했습니다.

---

### 이슈 번호
- 관련된 이슈 번호를 작성합니다. (예: Fixes #123, Closes #456)
