### PR TITLE
fix: override validate() of serializer to detect changes

### DIFF
--- a/srcs/backend/srcs/mysite/users/serializers.py
+++ b/srcs/backend/srcs/mysite/users/serializers.py
@@ -8,6 +8,13 @@ class CustomUserSerializer(serializers.ModelSerializer):
         model = CustomUser
         fields = ['id', 'username', 'email', 'profile_image']  # 필요한 필드만 선택
 
+    def validate(self, data):
+        instance = self.instance
+        for field, value in data.items():
+            if getattr(instance, field) == value:
+                raise serializers.ValidationError(f'The following field has not been changed: {field}')
+        return super().validate(data)
+
 class CustomUserPatternSerializer(serializers.ModelSerializer):
     user_list = serializers.SerializerMethodField()
 


### PR DESCRIPTION
## PR 제목
- override validate() of serializer to detect changes

## 작업 내용 (What)
- `PATCH api/users/me/`를 호출했는데 실제로 아무 데이터도 변경하지 않을 때 serializer.is_valid()에서 이를 오류로 처리하도록 하였습니다.

## 이유 (Why)
- 프론트엔드에서 요청했습니다.

## 변경 사항 (Changes)
- CustomUserSerializer의 validate()라는 메서드를 오버라이드했습니다.
- 마지막에 super().validate()로 부모 클래스인 ModelSerializer의 기본 검사 로직도 작동하도록 했습니다.

## 테스트 (How)
- Postman으로 테스트했습니다.
- username=seojilee인 유저.
<img width="397" alt="Screenshot 2025-02-27 at 10 07 28 PM" src="https://github.com/user-attachments/assets/6d36ac7b-c331-42fd-86d9-adec7e5d4a1b" />


## 참고 사항
- 리뷰어가 참고할 만한 추가 자료가 있다면 여기에 작성하세요.
  - 관련 링크, 문서, 이슈 번호 등.

---

### 체크리스트
- [x] 코드가 의도한 대로 작동합니다.
- [x] 변경 사항이 문서화되었습니다.
- [x] 기존 테스트를 통과했으며, 필요한 경우 새로운 테스트를 추가했습니다.

---

### 이슈 번호
- 관련된 이슈 번호를 작성합니다. (예: Fixes #123, Closes #456)
