### PR TITLE
Fix/patch users

### DIFF
--- a/srcs/backend/srcs/mysite/oauth/views.py
+++ b/srcs/backend/srcs/mysite/oauth/views.py
@@ -95,7 +95,7 @@ class TokenView(APIView):
             return Return({'error': f'Invalid username: {api_data["login"]}'})
 
         file_name = f'_{user.id}.png'
-        file_path = user.profile_image.field.upload_to + '/' + file_name
+        file_path = user.profile_image.field.upload_to(user, file_name)
 
         if not default_storage.exists(file_path):
             image_response = requests.get(api_data['image']['link'])

--- a/srcs/backend/srcs/mysite/oauth/views.py
+++ b/srcs/backend/srcs/mysite/oauth/views.py
@@ -95,9 +95,9 @@ class TokenView(APIView):
             return Return({'error': f'Invalid username: {api_data["login"]}'})
 
         file_name = f'_{user.id}.png'
-        file_path = user.profile_image.field.upload_to(user, file_name)
 
-        if not default_storage.exists(file_path):
+        files, _ = default_storage.listdir('profiles')
+        if not any(f.startswith(f'_{user.id}') for f in files):
             image_response = requests.get(api_data['image']['link'])
             if image_response.status_code != 200:
                 return Response(image_response.json(), status=image_response.status_code)

--- a/srcs/backend/srcs/mysite/users/models.py
+++ b/srcs/backend/srcs/mysite/users/models.py
@@ -8,10 +8,14 @@ def validate_username(pattern):
     if pattern in FORBIDDEN_PATTERNS:
         raise ValidationError(f'Cannot use {pattern} as username')
 
+def set_unique_filename(instance, filename):
+    extension = filename.split('.')[-1]
+    return f'profiles/_{instance.id}.{extension}'
+
 class CustomUser(AbstractUser):
     id = models.IntegerField(primary_key=True, blank=True,help_text="유저 고유 id")
     email = models.CharField(max_length=100, blank=True, help_text="인트라 이메일")
-    profile_image = models.FileField(upload_to='profiles/', null=True, help_text="프로필 이미지 경로")
+    profile_image = models.FileField(upload_to=set_unique_filename, null=True, help_text="프로필 이미지 경로")
     username = models.CharField(
         max_length=150,
         unique=True,

--- a/srcs/backend/srcs/mysite/users/serializers.py
+++ b/srcs/backend/srcs/mysite/users/serializers.py
@@ -16,7 +16,7 @@ class CustomUserSerializer(serializers.ModelSerializer):
         return super().validate(data)
 
     def update(self, instance, validated_data):
-        if instance.profile_image and os.path.isfile(instance.profile_image.path):
+        if 'profile_image' in validated_data and instance.profile_image and os.path.isfile(instance.profile_image.path):
                 os.remove(instance.profile_image.path)
         return super().update(instance, validated_data)
 

--- a/srcs/backend/srcs/mysite/users/serializers.py
+++ b/srcs/backend/srcs/mysite/users/serializers.py
@@ -1,7 +1,7 @@
 # serializers.py
 from rest_framework import serializers
 from .models import CustomUser
-import re
+import re, os
 
 class CustomUserSerializer(serializers.ModelSerializer):
     class Meta:
@@ -14,6 +14,11 @@ class CustomUserSerializer(serializers.ModelSerializer):
             if getattr(instance, field) == value:
                 raise serializers.ValidationError(f'The following field has not been changed: {field}')
         return super().validate(data)
+
+    def update(self, instance, validated_data):
+        if instance.profile_image and os.path.isfile(instance.profile_image.path):
+                os.remove(instance.profile_image.path)
+        return super().update(instance, validated_data)
 
 class CustomUserPatternSerializer(serializers.ModelSerializer):
     user_list = serializers.SerializerMethodField()


### PR DESCRIPTION
## PR 제목
- fix `PATCH api/users/me/`

## 작업 내용 (What)
- 프로필 사진은 무조건 _{user.id}.확장자로 저장되도록 함.

## 이유 (Why)
- 프로필 사진을 변경할 때마다 사용하지 않는 파일이 점점 쌓이는 것을 방지.

## 변경 사항 (Changes)
- CustomUser 모델에 FileField.upload_to 속성을 문자열이 아닌 함수로 변경하여 파일이 반드시 _{user.id}.확장자로 저장되도록 함.
- CustomUserSerializer의 update() 메서드를 오버라이드. 프로필 이미지를 변경할 때 기존 이미지를 먼저 삭제.
- 토큰 발급 뷰에서 로컬에 프로필 사진이 존재하는지 검색할 때 png 확장자로만 검색하지 않도록 확장자를 제외하고 검사.

## 테스트 (How)
- frontend 연결해서 테스트.
- 프로필 이미지 변경 후 로컬 스토리지 확인해보니 _{user.id}.확장자 이름의 파일 하나만 있었습니다.
- 데이터베이스 지우고 다시 42 로그인을 할 때도 잘 동작합니다.

## 참고 사항
- 리뷰어가 참고할 만한 추가 자료가 있다면 여기에 작성하세요.
  - 관련 링크, 문서, 이슈 번호 등.

---

### 체크리스트
- [x] 코드가 의도한 대로 작동합니다.
- [x] 변경 사항이 문서화되었습니다.
- [x] 기존 테스트를 통과했으며, 필요한 경우 새로운 테스트를 추가했습니다.

---

### 이슈 번호
- 관련된 이슈 번호를 작성합니다. (예: Fixes #123, Closes #456)
