### PR TITLE
Build/healthcheck postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,9 @@ services:
     volumes:
       - ./srcs/backend/srcs:/projects
     depends_on:
-      - database
+      database:
+        condition: service_healthy
+        restart: true
 
   database:
     init: true
@@ -60,6 +62,12 @@ services:
       - ft_trancendence
     volumes:
       - ./srcs/database/srcs:/var/lib/postgresql/data
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB" ]
+      start_period: 2s
+      interval: 5s
+      timeout: 10s
+      retries: 3
   # 테스트할 땐 주석 해제
   # redis:
   #   init: true
@@ -71,4 +79,3 @@ services:
 
 networks:
   ft_trancendence:
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,24 @@
 services:
-  # 테스트할 땐 주석 해제
-  # frontend:
-  #   init: true
-  #   build: ./srcs/frontend
-  #   image: frontend:42
-  #   container_name: frontend
-  #   environment:
-  #     DOMAIN_NAME: ${DOMAIN_NAME}
-  #     SSL_KEY: ${SSL_KEY}
-  #     SSL_CRT: ${SSL_CRT}
+# 테스트할 땐 주석 해제
+#  frontend:
+#    init: true
+#    build: ./srcs/frontend
+#    image: frontend:42
+#    container_name: frontend
+#    environment:
+#      DOMAIN_NAME: ${DOMAIN_NAME}
+#      SSL_KEY: ${SSL_KEY}
+#      SSL_CRT: ${SSL_CRT}
+#    ports:
+#      - "443:443"
+#      - "80:80"
+#    networks:
+#      - ft_trancendence
+#    volumes:
+#      - ./srcs/frontend/codes:/usr/share/nginx/html
+#    depends_on:
+#      - backend
 
-  #   ports:
-  #     - "443:443"
-  #     - "80:80"
-  #   networks:
-  #     - ft_trancendence
-  #   volumes:
-  #     - ./srcs/frontend/codes:/usr/share/nginx/html
   backend:
     init: true
     build: ./srcs/backend
@@ -68,14 +70,14 @@ services:
       interval: 5s
       timeout: 10s
       retries: 3
-  # 테스트할 땐 주석 해제
-  # redis:
-  #   init: true
-  #   image: redis:7
-  #   networks:
-  #     - ft_trancendence
-  #   ports:
-  #     - 6379:6379
+# 테스트할 땐 주석 해제
+#  redis:
+#    init: true
+#    image: redis:7
+#    networks:
+#      - ft_trancendence
+#    ports:
+#      - 6379:6379
 
 networks:
   ft_trancendence:


### PR DESCRIPTION
## PR 제목
- healthcheck postgres

## 작업 내용 (What)
- database healthcheck
- backend -> depends on postgres
- frontend -> depends on django

## 이유 (Why)
- 서비스 초기에 아직 postgres에 접속할 수 없는 상태에서 backend 컨테이너가 접속을 시도.
- postgres에 연결 가능한지 healthcheck로 확인하고 그 다음에 backend 컨테이너를 로드합니다.
- 프론트엔드도, postgres를 기다리느라 아직 시작되지 않은 백엔드 컨테이너를 참조하다가 오류가 나서 자꾸 꺼지길래 depends on을 넣어줬습니다.

## 변경 사항 (Changes)
- 구체적인 변경 사항을 나열합니다:
  - 파일 추가/수정/삭제
  - 의존성 추가 등

## 테스트 (How)
- 지금까지 이 변경사항을 로컬에 놔두고 계속 사용을 했는데 의도대로 작동했습니다.
- 데이터베이스 먼저 시작, 그 다음 백엔드, 그 다음 프론트엔드.

## 참고 사항
- 리뷰어가 참고할 만한 추가 자료가 있다면 여기에 작성하세요.
  - 관련 링크, 문서, 이슈 번호 등.

---

### 체크리스트
- [ ] 코드가 의도한 대로 작동합니다.
- [ ] 변경 사항이 문서화되었습니다.
- [ ] 기존 테스트를 통과했으며, 필요한 경우 새로운 테스트를 추가했습니다.

---

### 이슈 번호
- 관련된 이슈 번호를 작성합니다. (예: Fixes #123, Closes #456)
