### PR TITLE
fix: restrict manually changing is_online attr

### DIFF
--- a/srcs/backend/srcs/mysite/users/serializers.py
+++ b/srcs/backend/srcs/mysite/users/serializers.py
@@ -7,6 +7,7 @@ class CustomUserSerializer(serializers.ModelSerializer):
     class Meta:
         model = CustomUser
         fields = ['id', 'username', 'email', 'profile_image', 'is_online']  # 필요한 필드만 선택
+        read_only_fields = ['is_online']
 
     def validate(self, data):
         instance = self.instance


### PR DESCRIPTION
## PR 제목
- restrict manually changing is_online attr

## 작업 내용 (What)
- CustomUserSerializer에서 CustomUser의 is_online 속성을 읽기 전용으로 취급하도록 설정.
- 읽기 전용은 업데이트 시도가 있어도 무시됨.
- 시리얼라이저를 사용하지 않는 웹소켓 로직에서는 상관없음.

## 이유 (Why)
- 온라인 여부는 웹소켓으로만 판단. API 요청으로 임의로 변경할 수 없음.
- 프론트엔드에 이런 요청을 날리는 코드는 없지만 postman 등으로 변경 가능.

## 변경 사항 (Changes)
- 구체적인 변경 사항을 나열합니다:
  - 파일 추가/수정/삭제
  - 의존성 추가 등

## 테스트 (How)
- 이 변경 사항이 어떻게 테스트되었는지 설명합니다.
  - 수동 테스트, 유닛 테스트 등.

## 참고 사항
- 리뷰어가 참고할 만한 추가 자료가 있다면 여기에 작성하세요.
  - 관련 링크, 문서, 이슈 번호 등.

---

### 체크리스트
- [x] 코드가 의도한 대로 작동합니다.
- [x] 변경 사항이 문서화되었습니다.
- [x] 기존 테스트를 통과했으며, 필요한 경우 새로운 테스트를 추가했습니다.

---

### 이슈 번호
- 관련된 이슈 번호를 작성합니다. (예: Fixes #123, Closes #456)
