### PR TITLE
fix: return an empty list instead of 400 - no history

### DIFF
--- a/srcs/backend/srcs/mysite/game_records/views.py
+++ b/srcs/backend/srcs/mysite/game_records/views.py
@@ -12,8 +12,6 @@ class MatchAuthViewSet(viewsets.ViewSet):
     def list(self, request):
         user = request.user
         serializer = MatchHistorySerializer(user)
-        if not serializer.data.get('match_history'):
-            return Response({"error": "Data not found"}, status=400)
         return Response(serializer.data)
 
 class MatchViewSet(viewsets.ViewSet):
@@ -24,6 +22,4 @@ class MatchViewSet(viewsets.ViewSet):
         except CustomUser.DoesNotExist:
             return Response({"error": "User not found"}, status=400)
         serializer = MatchHistorySerializer(user)
-        if not serializer.data.get('match_history'):
-            return Response({"error": "Data not found"}, status=400)
         return Response(serializer.data)


### PR DESCRIPTION
## PR 제목
- return an empty list instead of 400 when there is no history found

## 작업 내용 (What)
- 게임 히스토리가 하나도 없을 때 빈 리스트를 반환.

## 이유 (Why)
- 프론트엔드에서 요청.
- 게임 기록은 없어도 기록 보여주는 페이지는 항상 존재하니까 에러보다는 빈 리스트를 보내주는 게 낫다고 생각합니다.

## 변경 사항 (Changes)
- 400 리턴 -> 빈 리스트 리턴.

## 테스트 (How)
- curl로 테스트.

## 참고 사항
- 리뷰어가 참고할 만한 추가 자료가 있다면 여기에 작성하세요.
  - 관련 링크, 문서, 이슈 번호 등.

---

### 체크리스트
- [x] 코드가 의도한 대로 작동합니다.
- [x] 변경 사항이 문서화되었습니다.
- [x] 기존 테스트를 통과했으며, 필요한 경우 새로운 테스트를 추가했습니다.

---

### 이슈 번호
- 관련된 이슈 번호를 작성합니다. (예: Fixes #123, Closes #456)
