### PR TITLE
feat: limit username length to 10

### DIFF
--- a/srcs/backend/srcs/mysite/users/models.py
+++ b/srcs/backend/srcs/mysite/users/models.py
@@ -17,7 +17,7 @@ class CustomUser(AbstractUser):
     email = models.CharField(max_length=100, blank=True, help_text="인트라 이메일")
     profile_image = models.FileField(upload_to=set_unique_filename, null=True, help_text="프로필 이미지 경로")
     username = models.CharField(
-        max_length=150,
+        max_length=10,
         unique=True,
         validators=[validate_username]
     )


### PR DESCRIPTION
## PR 제목
- 유저네임 길이를 10글자로 제한.

## 작업 내용 (What)
- 유저네임 길이를 10글자로 제한.

## 이유 (Why)
- 이름이 너무 길면 모바일 화면에 제대로 표시되지 않음.

## 변경 사항 (Changes)
- 150글자 제한을 10글자로 변경.

## 테스트 (How)
- 이 변경 사항이 어떻게 테스트되었는지 설명합니다.
  - 수동 테스트, 유닛 테스트 등.

## 참고 사항
- 리뷰어가 참고할 만한 추가 자료가 있다면 여기에 작성하세요.
  - 관련 링크, 문서, 이슈 번호 등.

---

### 체크리스트
- [x] 코드가 의도한 대로 작동합니다.
- [x] 변경 사항이 문서화되었습니다.
- [x] 기존 테스트를 통과했으며, 필요한 경우 새로운 테스트를 추가했습니다.

---

### 이슈 번호
- 관련된 이슈 번호를 작성합니다. (예: Fixes #123, Closes #456)
